### PR TITLE
Fix char array too small issue

### DIFF
--- a/src/elm327/PidProcessor.cpp
+++ b/src/elm327/PidProcessor.cpp
@@ -126,7 +126,7 @@ uint32_t PidProcessor:: getSupportedPids(uint8_t pid) {
 
 void PidProcessor::getFormattedResponse(char *response, uint8_t totalNumberOfChars, String pid, uint32_t value) {
     uint8_t nValueChars = totalNumberOfChars - PID_N_BYTES * N_CHARS_IN_BYTE;
-    char cValue[2];
+    char cValue[2 + 1];
     itoa(nValueChars, cValue, DEC);
     String mask = "%s%0";
     mask.concat(cValue);


### PR DESCRIPTION
cValue array is not large enough to include a string terminator IF nValueChars is larger than dec 9.   The next itoa function will write a string terminator over the end of the array corrupting whatever is there in memory.